### PR TITLE
Added opacity option

### DIFF
--- a/fullscreen-img.css
+++ b/fullscreen-img.css
@@ -5,6 +5,7 @@
 .fullscreen {
   background-size: cover; 
   -moz-background-size: cover;
+  opacity: 0.2;
 }
 
 .fullscreen .state-background {
@@ -53,3 +54,11 @@
   padding-top: 40px;
 }
 
+#imageContainer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: blue;
+}

--- a/fullscreen-img.js
+++ b/fullscreen-img.js
@@ -2,47 +2,79 @@
 // the body background image whenever this section is displayed.
 // TODO insert image with reveal transition
 var BGR;
+var imageContainer;
+var body;
 
-function fullscreen(event) {
+// Store background value
+BGR = document.body.style.background;
+
+function fullscreen(event, firstSlideOnLoad) {
   var url = event.currentSlide.getAttribute("fullscreen-img");
+
+  if (!firstSlideOnLoad) {
+    document.body.style.backgroundImage = "none";
+    var leftOver = document.getElementById('imageContainer');
+    if (leftOver) {
+      leftOver.parentNode.removeChild(imageContainer);
+    }
+  }
+
   if(url) {
-    if(typeof BGR == "undefined")
-    {
-      // Store background value
-      BGR = document.body.style.background;
+    // If user has specified opacity, create another element. Else, use body.
+    var opacity = event.currentSlide.getAttribute("fullscreen-opacity");
+    if (opacity) {
+      body = false;
+
+      // Create element and append to body
+      imageContainer = document.createElement("div");
+      imageContainer.id = "imageContainer";
+      imageContainer.style.opacity = opacity;
+      document.body.appendChild(imageContainer);
+    } else {
+      body = true;
+      imageContainer = document.body;
     }
 
     // Set image from fullscreen-img attribute as body background
-    document.body.style.backgroundImage = "url('" + url + "')";
+    imageContainer.style.backgroundImage = "url('" + url + "')";
+    
     var size = event.currentSlide.getAttribute("fullscreen-size");
     if(size != "contain") {
-      document.body.style.backgroundSize = "cover";
+      imageContainer.style.backgroundSize = "cover";
     }
     else {
       // Put image in 'contain' mode with black background
       // TODO store background color and use it. This is possible by regexping
       // the background property and replacing the 2nd value by the image url.
       // See http://www.w3schools.com/cssref/css3_pr_background.asp
-      document.body.style.backgroundColor = "#000000";
-      document.body.style.backgroundSize  = "contain";
-      document.body.style.backgroundRepeat = "no-repeat";
-      document.body.style.backgroundAttachment = "fixed";
-      document.body.style.backgroundPosition = "center center";
+      imageContainer.style.backgroundColor = "#000000";
+      imageContainer.style.backgroundSize  = "contain";
+      imageContainer.style.backgroundRepeat = "no-repeat";
+      imageContainer.style.backgroundAttachment = "fixed";
+      imageContainer.style.backgroundPosition = "center center";
     }
   }
+
   else { 
+    // Reset background to original style
     if(typeof BGR != "undefined") { 
-      document.body.style.backgroundImage = "none";
-      document.body.style.background      = BGR;
-    } 
+      document.body.style.background = BGR;
+    }     
+
+    // Reset imageContainer var
+    if (!body) {
+      imageContainer = '';
+    }
   }
+
+
+
 }
 
 Reveal.addEventListener('ready', function(event) {
-  fullscreen(event);
+  fullscreen(event, true);
 }, false );
 
 Reveal.addEventListener('slidechanged', function(event) {
-  fullscreen(event);
+  fullscreen(event, false);
 }, false );
-


### PR DESCRIPTION
You might want to have a review of my code, I'm sure it can be optimised. I only tested in Chrome 27.0.1453.110 so it might be worth doing some cross browser.
- Added opacity value to the section tag (fullscreen-opacity(0.x))
- Added a bool to the event listeners; if you reloaded the presentation
  halfway through it would call both and then you'd have a leftover image
  (with opacity, anway).
- Opacity mode creates a new dom element, and then removes it on
  transition. Non opacity mode remains the same as it was, as it's
  faster. Stops the DOM from repainting so much.
- Assigned the imageContainer/document.body into a var to stop multiple
  requests
