### PR TITLE
Make images content based instead of metadata based. 

### DIFF
--- a/README
+++ b/README
@@ -31,6 +31,15 @@ A title page:
     <h2>Interesting subtitle</h2>
   </section>
 
+Alternately, you can include an image, then give it a class of 'fullscreen-img' and 
+it will be set to display none, and included as the background image:
+
+  <section>
+    <h1>A Fantastic Title</h1>
+    <h2>Interesting subtitle</h2>
+    <img src="img/cover_image.jpg" class="fullscreen-img" />
+  </section>
+
 If you want to scale the image so that the entire image is contained in the
 slide, add a fullscreen-size attribute with value "contain" to your section:
 

--- a/fullscreen-img.css
+++ b/fullscreen-img.css
@@ -53,3 +53,7 @@
   padding-top: 40px;
 }
 
+.fullscreen-img{
+  display: none;
+}
+

--- a/fullscreen-img.js
+++ b/fullscreen-img.js
@@ -4,11 +4,19 @@
 var BGR;
 
 function fullscreen(event) {
-  var url = event.currentSlide.getAttribute("fullscreen-img");
+
+  var contentImg = event.currentSlide.querySelector(".fullscreen-img");
+  if (contentImg){
+      var url = contentImg.src;
+      contentImg.style.display = 'none';
+  }
+  else{
+      var url = event.currentSlide.getAttribute("fullscreen-img");
+  }
+
+  
   var backgroundholder = document.querySelector(".state-background"); 
   if(url) {
-    
-
 
     if(typeof BGR == "undefined")
     {

--- a/fullscreen-img.js
+++ b/fullscreen-img.js
@@ -5,35 +5,41 @@ var BGR;
 
 function fullscreen(event) {
   var url = event.currentSlide.getAttribute("fullscreen-img");
+  var backgroundholder = document.querySelector(".state-background"); 
   if(url) {
+    
+
+
     if(typeof BGR == "undefined")
     {
       // Store background value
-      BGR = document.body.style.background;
+      BGR = backgroundholder.style.background;
     }
 
+
+
     // Set image from fullscreen-img attribute as body background
-    document.body.style.backgroundImage = "url('" + url + "')";
+    backgroundholder.style.backgroundImage = "url('" + url + "')";
     var size = event.currentSlide.getAttribute("fullscreen-size");
     if(size != "contain") {
-      document.body.style.backgroundSize = "cover";
+      backgroundholder.style.backgroundSize = "cover";
     }
     else {
       // Put image in 'contain' mode with black background
       // TODO store background color and use it. This is possible by regexping
       // the background property and replacing the 2nd value by the image url.
       // See http://www.w3schools.com/cssref/css3_pr_background.asp
-      document.body.style.backgroundColor = "#000000";
-      document.body.style.backgroundSize  = "contain";
-      document.body.style.backgroundRepeat = "no-repeat";
-      document.body.style.backgroundAttachment = "fixed";
-      document.body.style.backgroundPosition = "center center";
+      backgroundholder.style.backgroundColor = "#000000";
+      backgroundholder.style.backgroundSize  = "contain";
+      backgroundholder.style.backgroundRepeat = "no-repeat";
+      backgroundholder.style.backgroundAttachment = "fixed";
+      backgroundholder.style.backgroundPosition = "center center";
     }
   }
   else { 
     if(typeof BGR != "undefined") { 
-      document.body.style.backgroundImage = "none";
-      document.body.style.background      = BGR;
+      backgroundholder.style.backgroundImage = "none";
+      backgroundholder.style.background      = BGR;
     } 
   }
 }


### PR DESCRIPTION
I added the ability to pull in an image from a slide to be the full screen image.  This way, if you wanted to show the image one way in printing, and another way in preso mode, you could.  

Additionally, i moved the target of the background image to the state background instead of the body.  This allows you to apply css to the image if you want to independent from the entire document. 
